### PR TITLE
Updates for kernel 2.6.33 and later; README fix

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 This is kernel module source for CrystalFontz CFA779 device.
-That device can be found on Qualsys firewalls.
+That device can be found on Qualys firewalls.
 
 Module creates control files in sysfs and provides event device so you can read key events from keypad.
 

--- a/cfa779.c
+++ b/cfa779.c
@@ -98,7 +98,7 @@ static struct i2c_driver cfa779_driver = {
     .probe = cfa779_probe,
     .remove = cfa779_remove,
 
-    .address_data = &addr_data,
+    .address_list = normal_i2c,
     .detect = cfa779_detect
 };
 

--- a/cfa779.c
+++ b/cfa779.c
@@ -77,7 +77,7 @@ struct cfa779_data
 static int cfa779_probe (struct i2c_client *client,
                          const struct i2c_device_id *id);
 static int cfa779_remove (struct i2c_client *client);
-static int cfa779_detect (struct i2c_client *client, int kind,
+static int cfa779_detect (struct i2c_client *client,
                           struct i2c_board_info *board_info);
 
 struct i2c_device_id cfa779_idtable[] = {
@@ -467,7 +467,7 @@ lcd_send_packet (struct i2c_client *client, u8 idx, int len, char *data)
 
 
 static int
-cfa779_detect (struct i2c_client *new_client, int kind,
+cfa779_detect (struct i2c_client *new_client,
                struct i2c_board_info *info)
 {
     struct i2c_adapter *adapter = new_client->adapter;
@@ -477,26 +477,12 @@ cfa779_detect (struct i2c_client *new_client, int kind,
         return -ENODEV;
 
     /*
-     * Now we do the remaining detection. A negative kind means that
-     * the driver was loaded with no force parameter (default), so we
-     * must both detect and identify the chip. A zero kind means that
-     * the driver was loaded with the force parameter, the detection
-     * step shall be skipped. A positive kind means that the driver
-     * was loaded with the force parameter and a given kind of chip is
-     * requested, so both the detection and the identification steps
-     * are skipped.
+     * Now we must both detect and identify the chip.
      */
 
-    if (kind == 0)
-        kind = cfa779;
-
-    if (kind < 0)
-      {                         /* detection and identification */
-          lcd_send_packet (new_client, 0, 0, NULL);
-          if (lcd_check_reply (new_client, 0, 0, NULL) == 0)
-              return -ENODEV;
-          kind = cfa779;
-      }
+    lcd_send_packet (new_client, 0, 0, NULL);
+    if (lcd_check_reply (new_client, 0, 0, NULL) == 0)
+        return -ENODEV;
 
     strncpy (info->type, "cfa779", I2C_NAME_SIZE);
 

--- a/cfa779.c
+++ b/cfa779.c
@@ -58,8 +58,6 @@ MODULE_LICENSE ("GPL");
 
 static const unsigned short normal_i2c[] = { 0x20, I2C_CLIENT_END };
 
-I2C_CLIENT_INSMOD_1 (cfa779);
-
 /* ---------------------------------------------------------------------*/
 
 /* Each client has this additional data */

--- a/cfa779.c
+++ b/cfa779.c
@@ -62,22 +62,6 @@ I2C_CLIENT_INSMOD_1 (cfa779);
 
 /* ---------------------------------------------------------------------*/
 
-s32
-i2c_smbus_read_block_data (struct i2c_client *client, u8 command, u8 * values)
-{
-    union i2c_smbus_data data;
-    int i;
-    if (i2c_smbus_xfer (client->adapter, client->addr, client->flags,
-                        I2C_SMBUS_READ, command, I2C_SMBUS_BLOCK_DATA, &data))
-        return -1;
-    else
-      {
-          for (i = 1; i <= data.block[0]; i++)
-              values[i - 1] = data.block[i];
-          return data.block[0];
-      }
-}
-
 /* Each client has this additional data */
 struct cfa779_data
 {


### PR DESCRIPTION
This PR provides the changes needed for this driver to work with Linux kernel 2.6.33 and later.

I have tested this driver on a Raspberry Pi running a 64-bit 5.4 kernel, using a CFA-779 v1.0r (dated 2001-07-03, pulled from an eSoft InstaGate EX2 firewall appliance). I can use this driver to write to the LCD, but have not had success reading keypad state or any other data from it ("invalid CRC" errors are reported; I am not aware of the cause).